### PR TITLE
docs: GH-5 Creating issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: Create a report if you find an issue using the SDK
+title: "[BUG]: "
+labels: bug
+assignees: Tohaker
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Share a code snippet or a reproduction repository demonstrating the bug.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**System information (please complete the following information):**
+ - OS: [e.g. Ubuntu 24.04]
+ - Go Version [e.g. 1.24]
+ - SDK Version [e.g. 1.0.0]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[FEATURE]:"
+labels: enhancement
+assignees: Tohaker
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: "[FEATURE]:"
+title: "[FEATURE]: "
 labels: enhancement
 assignees: Tohaker
 

--- a/.github/ISSUE_TEMPLATE/specification-issue.md
+++ b/.github/ISSUE_TEMPLATE/specification-issue.md
@@ -2,7 +2,7 @@
 name: Specification issue
 about: Report an issue with the underlying OpenAPI specification
 title: "[SPEC]: "
-labels: ''
+labels: specification
 assignees: Tohaker
 
 ---

--- a/.github/ISSUE_TEMPLATE/specification-issue.md
+++ b/.github/ISSUE_TEMPLATE/specification-issue.md
@@ -1,0 +1,20 @@
+---
+name: Specification issue
+about: Report an issue with the underlying OpenAPI specification
+title: "[SPEC]: "
+labels: ''
+assignees: Tohaker
+
+---
+
+**Which part of the specification has an issue?**
+Preferably link to the page in the [official documentation](https://use1-omada-northbound.tplinkcloud.com/doc.html#/home)
+
+**Describe the problem with the specification**
+For example; "The response type for `CreateNewSite` is incorrect"
+
+**What do you expect the correct behaviour to be?**
+For example; "The response should have the `siteId` in the body"
+
+**Additional context**
+Add any other context or screenshots about the issue here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+**What does this PR do?**
+<!-- Describe the contents of the PR, and its expected behaviour -->
+
+**Why is this PR needed?**
+<!-- What problem does this PR solve? -->
+
+<!-- (Optional) Issue number this PR addresses -->
+Closes #
+
+**How to test:**
+
+<!-- Provide detailed testing instructions -->
+
+**Completion checklist:**
+
+- [ ] Added tests
+- [ ] Updated documentation


### PR DESCRIPTION
**What does this PR do?**
Adds issue form templates and a PR template to the repo

**Why is this PR needed?**
We want a standard form of issue and PR to help external users to engage better with the project

Closes #5

**How to test:**

Once merged, try to create a PR and an Issue. We should be served a template of some kind

**Completion checklist:**

- [ ] Added tests
- [ ] Updated documentation